### PR TITLE
fix: add Unsplash to CSP, replace thumbnails with local SVG

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -76,7 +76,7 @@ export default defineConfig({
         "object-src 'self'",
         "connect-src 'self' https://challenges.cloudflare.com",
         "base-uri 'self'",
-        "img-src 'self' https://res.cloudinary.com/dellp9a4z/ data:",
+        "img-src 'self' https://res.cloudinary.com/dellp9a4z/ https://images.unsplash.com data:",
         "media-src 'self' https://res.cloudinary.com/dellp9a4z/",
         "font-src 'self' data:",
         "frame-src 'self' https://challenges.cloudflare.com",

--- a/public/thumbnails/dev-session.svg
+++ b/public/thumbnails/dev-session.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0d0d1a"/>
+      <stop offset="100%" style="stop-color:#1a1040"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <!-- Terminal window -->
+  <rect x="200" y="140" width="800" height="350" rx="12" fill="#1e1e2e" stroke="#3d3d6b" stroke-width="1.5"/>
+  <rect x="200" y="140" width="800" height="40" rx="12" fill="#2a2a3e"/>
+  <rect x="200" y="160" width="800" height="20" fill="#2a2a3e"/>
+  <circle cx="230" cy="160" r="7" fill="#ff5f57"/>
+  <circle cx="255" cy="160" r="7" fill="#febc2e"/>
+  <circle cx="280" cy="160" r="7" fill="#28c840"/>
+  <!-- Code lines -->
+  <rect x="230" y="210" width="340" height="10" rx="4" fill="#cbb7fb" opacity="0.9"/>
+  <rect x="230" y="235" width="220" height="10" rx="4" fill="#89dceb" opacity="0.7"/>
+  <rect x="250" y="260" width="280" height="10" rx="4" fill="#a6e3a1" opacity="0.7"/>
+  <rect x="250" y="285" width="180" height="10" rx="4" fill="#f9e2af" opacity="0.7"/>
+  <rect x="230" y="310" width="300" height="10" rx="4" fill="#cba6f7" opacity="0.8"/>
+  <rect x="230" y="335" width="140" height="10" rx="4" fill="#89dceb" opacity="0.6"/>
+  <rect x="230" y="360" width="260" height="10" rx="4" fill="#a6e3a1" opacity="0.5"/>
+  <!-- Cursor -->
+  <rect x="230" y="390" width="12" height="18" rx="2" fill="#cbb7fb" opacity="0.9"/>
+  <!-- Label -->
+  <text x="600" y="555" text-anchor="middle" font-family="monospace" font-size="22" fill="#cbb7fb" opacity="0.7">dev-session · 2026-04-25</text>
+</svg>

--- a/public/thumbnails/devlog-bootstrap.svg
+++ b/public/thumbnails/devlog-bootstrap.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="bg2" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0d0d1a"/>
+      <stop offset="100%" style="stop-color:#0d2040"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg2)"/>
+  <!-- Connection lines -->
+  <line x1="600" y1="315" x2="350" y2="200" stroke="#cbb7fb" stroke-width="1.5" opacity="0.4"/>
+  <line x1="600" y1="315" x2="850" y2="200" stroke="#cbb7fb" stroke-width="1.5" opacity="0.4"/>
+  <line x1="600" y1="315" x2="350" y2="430" stroke="#cbb7fb" stroke-width="1.5" opacity="0.4"/>
+  <line x1="600" y1="315" x2="850" y2="430" stroke="#cbb7fb" stroke-width="1.5" opacity="0.4"/>
+  <line x1="600" y1="315" x2="600" y2="160" stroke="#89dceb" stroke-width="1.5" opacity="0.4"/>
+  <line x1="600" y1="315" x2="600" y2="470" stroke="#89dceb" stroke-width="1.5" opacity="0.4"/>
+  <!-- Nodes -->
+  <circle cx="600" cy="315" r="28" fill="#cbb7fb" opacity="0.95"/>
+  <circle cx="350" cy="200" r="18" fill="#89dceb" opacity="0.8"/>
+  <circle cx="850" cy="200" r="18" fill="#89dceb" opacity="0.8"/>
+  <circle cx="350" cy="430" r="18" fill="#a6e3a1" opacity="0.8"/>
+  <circle cx="850" cy="430" r="18" fill="#a6e3a1" opacity="0.8"/>
+  <circle cx="600" cy="160" r="14" fill="#f9e2af" opacity="0.8"/>
+  <circle cx="600" cy="470" r="14" fill="#f9e2af" opacity="0.8"/>
+  <!-- Label -->
+  <text x="600" y="555" text-anchor="middle" font-family="monospace" font-size="22" fill="#89dceb" opacity="0.7">dev-log bootstrap · Hermes Agent</text>
+</svg>

--- a/src/content/blog/2026-04-25-dev-session.md
+++ b/src/content/blog/2026-04-25-dev-session.md
@@ -8,7 +8,7 @@ pubDate: 2026-04-25T18:00:00.000Z
 license: mit
 tags: [piano, dev-log, tone-js, bugfix, cleanup]
 image:
-  src: https://images.unsplash.com/photo-1520523839897-bd0b52f945a0?w=1200&q=80
+  src: /thumbnails/dev-session.svg
   alt: 鋼琴琴鍵特寫
 ---
 

--- a/src/content/blog/2026-04-25-devlog-bootstrap.md
+++ b/src/content/blog/2026-04-25-devlog-bootstrap.md
@@ -8,7 +8,7 @@ pubDate: 2026-04-25T12:00:00.000Z
 license: mit
 tags: [dev-log, astro, hermes-agent, automation]
 image:
-  src: https://images.unsplash.com/photo-1461749280684-dccba630e2f6?w=1200&q=80
+  src: /thumbnails/devlog-bootstrap.svg
   alt: 程式碼與鍵盤的開發現場
 ---
 


### PR DESCRIPTION
Closes #15

## Root Cause
CSP `img-src` only allowed `'self'` and Cloudinary. Unsplash URLs were blocked.

Browser error:
```
Loading the image 'https://images.unsplash.com/...' violates CSP img-src directive
```

## Fix
1. Added `https://images.unsplash.com` to `img-src` in `astro.config.mjs`
2. Replaced Unsplash URLs in 2 articles with self-hosted SVG thumbnails:
   - `public/thumbnails/dev-session.svg` — dark terminal/code theme
   - `public/thumbnails/devlog-bootstrap.svg` — network nodes theme
3. `piano-screenshot.png` already worked (self-hosted)

## Verified
- Build passes, all 3 thumbnails present in `dist/`