### PR TITLE
fix: update LICENSE copyright to Miksin

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Daniel Adrian
+Copyright (c) 2026 Miksin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
LICENSE 版權人從範本作者 Daniel Adrian 改為 Miksin。\n\nCloses #18