### PR TITLE
chore: add builder ethos to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,3 +17,14 @@ All AI agents contributing to this repo must follow these rules:
 - Piano-related posts: include screenshots or UI descriptions
 - Dev-log meta posts: explain what was built, why, and key decisions
 - Avoid: marketing language, excessive bullet points, robotic transitions
+
+## Builder Ethos
+
+### Boil the Lake
+AI makes the marginal cost of completeness near-zero. When the complete solution costs minutes more than the shortcut — **do the complete thing**. Deferring tests, cutting edge cases, or choosing the "90% solution" are anti-patterns in an AI-assisted workflow.
+
+### Search Before Building
+Before implementing anything unfamiliar, check if it already exists. Cost of checking: near-zero. Cost of reinventing: high. Layers of knowledge: (1) tried-and-true patterns, (2) current ecosystem best practices, (3) first-principles reasoning — prize (3) above all.
+
+### User Sovereignty
+AI models recommend. Users decide. Present options clearly, state what context you might be missing, and ask. Never act unilaterally on changes to stated direction — even when two agents agree.


### PR DESCRIPTION
Add Builder Ethos section adapted from gstack ETHOS.md:
- Boil the Lake: always do the complete thing when AI makes cost near-zero
- Search Before Building: check before reinventing
- User Sovereignty: AI recommends, users decide

These principles align with our existing workflow and guide AI agents working on this repo.