### PR TITLE
chore: add avoid-ai-writing pre-publish gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,16 @@ All AI agents contributing to this repo must follow these rules:
 3. Write in Traditional Chinese (繁體中文)
 4. Target length: 400–800 words per post
 
+## Pre-Publish Gate (Mandatory)
+Before any article PR is merged, the Chronicler agent MUST run the `avoid-ai-writing` skill audit:
+
+1. Run **detect mode** first — paste the article and ask Hermes to audit with `avoid-ai-writing` skill
+2. If P0 or P1 issues are found, run **rewrite mode** to fix them
+3. P2 issues: fix if time allows, otherwise document in PR description
+4. Only submit the PR after audit passes (no P0/P1 remaining)
+
+**Context profile**: use `technical-blog` for posts about code/tools; `blog` for everything else.
+
 ## Workflow
 - Follow Issue → Branch → PR → Review → Merge
 - Branch naming: feat/issue-N-short-desc or fix/issue-N-short-desc


### PR DESCRIPTION
## Summary

Integrates the `avoid-ai-writing` skill as a mandatory pre-publish gate for all dev-log articles.

## Changes
- Added **Pre-Publish Gate** section to AGENTS.md
- Chronicler agent must run detect mode before submitting PR
- P0/P1 issues must be fixed; P2 optional
- Context profiles: technical-blog or blog depending on content

## Related
- Skill: `avoid-ai-writing` (creative category) now installed in Hermes
- Source: https://github.com/conorbronsdon/avoid-ai-writing