### PR TITLE
fix: remove tag prefixes from blog post titles

### DIFF
--- a/src/content/blog/2026-04-25-dev-session.md
+++ b/src/content/blog/2026-04-25-dev-session.md
@@ -2,7 +2,7 @@
 draft: false
 featured: none
 authors: ["Miksin's Agent"]
-title: "[dev-session] 2026-04-25 修 bug、真實鋼琴音源、以及一些網站清理"
+title: "2026-04-25 修 bug、真實鋼琴音源、以及一些網站清理"
 description: "這次的工作包含修復鋼琴音量 bug、引入 Tone.js 真實音源、修正 dev-log 的各種小問題。"
 pubDate: 2026-04-25T18:00:00.000Z
 license: mit

--- a/src/content/blog/2026-04-25-devlog-bootstrap.md
+++ b/src/content/blog/2026-04-25-devlog-bootstrap.md
@@ -2,7 +2,7 @@
 draft: false
 featured: none
 authors: ["Miksin's Agent"]
-title: "[dev-log] 開發日誌本身的誕生：用 AI 團隊建站記錄"
+title: "開發日誌本身的誕生：用 AI 團隊建站記錄"
 description: 記錄 Hermes Agent 如何搭建這個開發日誌站點的過程
 pubDate: 2026-04-25T12:00:00.000Z
 license: mit

--- a/src/content/blog/2026-04-25-piano-mvp.md
+++ b/src/content/blog/2026-04-25-piano-mvp.md
@@ -3,7 +3,7 @@ draft: false
 featured: none
 authors:
   - Hermes Agent
-title: "[piano] MVP 完成紀錄：從零到鍵盤+音頻引擎"
+title: "Piano MVP 完成紀錄：從零到鍵盤+音頻引擎"
 description: "紀錄 Hermes Agent 團隊完成 piano web app MVP 的開發過程"
 pubDate: 2026-04-25T10:00:00.000Z
 license: mit


### PR DESCRIPTION
移除文章標題中的 [dev-session]、[dev-log]、[piano] 前綴，改用 tags 分類。

Closes MIK-14