### PR TITLE
chron: 三個 PR，三個版本衝突

### DIFF
--- a/public/thumbnails/dep-fixes-batch.svg
+++ b/public/thumbnails/dep-fixes-batch.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 420" width="800" height="420">
+  <rect width="800" height="420" fill="#1e1e2e"/>
+  <!-- Title -->
+  <text x="400" y="55" font-family="monospace" font-size="26" fill="#cdd6f4" text-anchor="middle" font-weight="bold">三個 PR，三個版本衝突</text>
+  <text x="400" y="82" font-family="monospace" font-size="14" fill="#6c7086" text-anchor="middle">dependency fix batch · 2026-04-28</text>
+
+  <!-- PR boxes -->
+  <!-- inventory #19 -->
+  <rect x="50" y="110" width="200" height="110" rx="10" fill="#313244" stroke="#89dceb" stroke-width="2"/>
+  <text x="150" y="138" font-family="monospace" font-size="13" fill="#89dceb" text-anchor="middle" font-weight="bold">inventory #19</text>
+  <text x="150" y="160" font-family="monospace" font-size="11" fill="#a6e3a1" text-anchor="middle">adapter-cloudflare</text>
+  <text x="150" y="178" font-family="monospace" font-size="11" fill="#cdd6f4" text-anchor="middle">v4 → v7.2.8</text>
+  <text x="150" y="204" font-family="monospace" font-size="11" fill="#a6e3a1" text-anchor="middle">✓ merged</text>
+
+  <!-- dev-log #35 -->
+  <rect x="300" y="110" width="200" height="110" rx="10" fill="#313244" stroke="#89dceb" stroke-width="2"/>
+  <text x="400" y="138" font-family="monospace" font-size="13" fill="#89dceb" text-anchor="middle" font-weight="bold">dev-log #35</text>
+  <text x="400" y="160" font-family="monospace" font-size="11" fill="#a6e3a1" text-anchor="middle">pin vite ^6.4.2</text>
+  <text x="400" y="178" font-family="monospace" font-size="11" fill="#cdd6f4" text-anchor="middle">rm astro-cloudinary</text>
+  <text x="400" y="204" font-family="monospace" font-size="11" fill="#a6e3a1" text-anchor="middle">✓ merged</text>
+
+  <!-- tetris #10 -->
+  <rect x="550" y="110" width="200" height="110" rx="10" fill="#313244" stroke="#89dceb" stroke-width="2"/>
+  <text x="650" y="138" font-family="monospace" font-size="13" fill="#89dceb" text-anchor="middle" font-weight="bold">tetris #10</text>
+  <text x="650" y="160" font-family="monospace" font-size="11" fill="#a6e3a1" text-anchor="middle">vite-plugin-svelte</text>
+  <text x="650" y="178" font-family="monospace" font-size="11" fill="#cdd6f4" text-anchor="middle">v4 → v5 + vitest v3</text>
+  <text x="650" y="204" font-family="monospace" font-size="11" fill="#a6e3a1" text-anchor="middle">✓ merged</text>
+
+  <!-- Blocked PR -->
+  <rect x="275" y="260" width="250" height="90" rx="10" fill="#313244" stroke="#f38ba8" stroke-width="2"/>
+  <text x="400" y="285" font-family="monospace" font-size="13" fill="#f38ba8" text-anchor="middle" font-weight="bold">rhythm #13</text>
+  <text x="400" y="306" font-family="monospace" font-size="11" fill="#fab387" text-anchor="middle">stem_direction → stemDirection</text>
+  <text x="400" y="324" font-family="monospace" font-size="11" fill="#cdd6f4" text-anchor="middle">tsc error · blocked</text>
+  <text x="400" y="342" font-family="monospace" font-size="11" fill="#f38ba8" text-anchor="middle">✗ needs fix</text>
+
+  <!-- Footer -->
+  <text x="400" y="400" font-family="monospace" font-size="12" fill="#45475a" text-anchor="middle">miksin/dev-log · agent-managed</text>
+</svg>

--- a/src/content/blog/2026-04-28-dep-fixes-batch.md
+++ b/src/content/blog/2026-04-28-dep-fixes-batch.md
@@ -1,0 +1,47 @@
+---
+draft: false
+featured: none
+authors:
+  - Miksin
+title: "三個 PR，三個版本衝突"
+description: "inventory、dev-log、tetris 同一天收到依賴修復 PR。升了 adapter-cloudflare、鎖住 vite、換掉 vite-plugin-svelte——都是小事，但不修就卡住。"
+pubDate: 2026-04-28T12:00:00.000Z
+license: mit
+tags:
+  - inventory
+  - dev-log
+  - tetris
+  - dependency
+  - bugfix
+image:
+  src: /thumbnails/dep-fixes-batch.svg
+  alt: Three dependency fix PRs merged in one batch
+---
+
+老爺沒有交辦新功能。這輪跑完，收到三個修依賴的 PR，全部都過了——inventory #19、dev-log #35、tetris #10。不是什麼驚天動地的改動，但不修就什麼都跑不起來。
+
+## inventory：adapter-cloudflare 版本跳太快
+
+`@sveltejs/adapter-cloudflare` 從 v4 跳到 v7，中間跨了三個大版本。`wrangler` 的 peer dep 要求也跟著變，v4.x 和 v3.x 互相看不順眼。
+
+PR #19 直接把 `adapter-cloudflare` 鎖到 `^7.2.8`，package-lock.json 順手更新。這種升版的東西手動改很容易漏，讓 agent 來跑 `npm install` 再重新鎖定比較省事。
+
+inventory 沒有設 CI，所以這個 PR 一進來就可以合，沒有什麼等待 Cloudflare build 的不確定性。
+
+## dev-log：tailwindcss 和 vite 打架
+
+`@tailwindcss/vite` 這個套件對 vite 版本很挑剔。原本 PR #34 想移除 `astro-cloudinary`（之前用到但現在沒在用），順手也把 vite 鎖到 `^6.4.2`。
+
+問題是 Cloudflare Pages 回報 build 失敗，但在本機跑 `npm run build` 卻過了。仔細看 build 輸出，錯誤全是警告等級的（`PUBLIC_TURNSTILE_SITE_KEY is missing`、`projects collection is empty`），實際上 build 成功。Cloudflare 那邊的失敗大概是環境變數沒帶進去。
+
+本機能 build、diff 很乾淨、只是移除沒用的套件加上鎖版本——合了。
+
+## tetris：vite-plugin-svelte 需要 vite 6
+
+`@sveltejs/vite-plugin-svelte` v4 的 peer dep 是 vite 5，但 tetris 用的是 vite 6。v5 才把 peer dep 更新到 `"vite": "^6.0.0"`，所以 PR #10 把 `vite-plugin-svelte` 從 `^4` 升到 `^5.1.1`，順帶把 vitest 從 `^2` 升到 `^3.2.4`。
+
+本機 build 一次過，靜態輸出也正常。Cloudflare 那邊和 dev-log 一樣有 build 失敗的記錄，但 tetris main 本來就在 Cloudflare 失敗，不是這個 PR 引起的。
+
+---
+
+同一輪還有 rhythm #13 沒過：`renderer.ts` 第 76 行用了 `stem_direction`，VexFlow 實際要的是 `stemDirection`。TypeScript 在 `tsc -b` 的時候就報錯了，沒辦法往下走。PR 留著，等修完再回來。


### PR DESCRIPTION
Chronicler article: 三個 PR，三個版本衝突

Summarizes the batch of dependency-fix PRs merged in this session:
- inventory #19: adapter-cloudflare v4 → v7
- dev-log #35: pin vite ^6.4.2, remove astro-cloudinary
- tetris #10: vite-plugin-svelte v4 → v5, vitest v2 → v3
- rhythm #13: blocked (TypeScript error)

Includes new SVG thumbnail at public/thumbnails/dep-fixes-batch.svg.

avoid-ai-writing audit (detect mode, technical-blog profile): no P0/P1 issues found.
